### PR TITLE
Add BINDER button

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1,3 +1,6 @@
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/ajwdewit/pcse_notebooks/HEAD
+
 A collection of PCSE notebooks
 ==============================
 


### PR DESCRIPTION
Hi Allard,
I just added a BINDER button to the README. BINDER provides free hosting for Jupyter notebooks.
By clicking the button, the visitor is automatically directed towards an interactive instance of the repo.
Here is the permanent link toward which the button points to:
https://hub.gke2.mybinder.org/user/ajwdewit-pcse_notebooks-o16h1xng/tree